### PR TITLE
Install pkg-config to probe ICU headers/libraries

### DIFF
--- a/postgres-base/install_extensions.sh
+++ b/postgres-base/install_extensions.sh
@@ -10,6 +10,7 @@ BUILD_DEPS=" \
     libc6-dev \
     libicu-dev \
     make \
+    pkg-config \
     postgresql-server-dev-9.6"
 
 ICU_PKG=$(apt-cache search --names-only '^libicu5[0-9]$' | awk '{print $1}')
@@ -40,7 +41,7 @@ make_extension() {
 }
 
 make_extension 'metabrainz' 'dbmirror' 'e050578'
-make_extension 'metabrainz' 'postgresql-musicbrainz-collate' '958142e'
+make_extension 'metabrainz' 'postgresql-musicbrainz-collate' '6c350bc'
 make_extension 'metabrainz' 'postgresql-musicbrainz-unaccent' 'b727896'
 make_extension 'omniti-labs' 'pg_amqp' '1290d7c'
 


### PR DESCRIPTION
Follow postgresql-musicbrainz-collate’s switch to pkg-config at https://github.com/metabrainz/postgresql-musicbrainz-collate/pull/5

(Work-in-progress incidentally pushed to master as https://github.com/metabrainz/docker-postgres/commit/922a9385645466e0ca93479a91b24d5ace9551a0 then correctly reverted in https://github.com/metabrainz/docker-postgres/commit/917d6dc52ef500dff7435555c7fd83fbd9d16b86.)